### PR TITLE
Object based filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ build/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
+Gemfile.lock
 # .ruby-version
 # .ruby-gemset
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in gemstash.gemspec
+gemspec

--- a/examples/caps_object.rb
+++ b/examples/caps_object.rb
@@ -8,6 +8,5 @@ require 'pandoc-filter'
 PandocElement.filter do |element|
   if element.kind_of?(PandocElement::Str)
     element.value.upcase!
-    nil
   end
 end

--- a/examples/caps_object.rb
+++ b/examples/caps_object.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require 'pandoc-filter'
+
+# Pandoc filter to convert all regular text to uppercase.
+# Code, link URLs, etc. are not affected.
+
+PandocElement.filter do |element|
+  if element.kind_of?(PandocElement::Str)
+    element.value.upcase!
+    nil
+  end
+end

--- a/examples/comments_object.rb
+++ b/examples/comments_object.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require 'pandoc-filter'
+
+incomment = false
+
+PandocElement.filter do |element|
+  if element.kind_of?(PandocElement::RawBlock)
+    if element.format == 'html'
+      if /<!-- BEGIN COMMENT -->/.match(element.value)
+        incomment = true
+        next []
+      elsif /<!-- END COMMENT -->/.match(element.value)
+        incomment = false
+        next []
+      end
+    end
+  end
+
+  next [] if incomment
+end

--- a/examples/comments_object.rb
+++ b/examples/comments_object.rb
@@ -4,7 +4,7 @@ require 'pandoc-filter'
 
 incomment = false
 
-PandocElement.filter do |element|
+PandocElement.filter! do |element|
   if element.kind_of?(PandocElement::RawBlock)
     if element.format == 'html'
       if /<!-- BEGIN COMMENT -->/.match(element.value)

--- a/examples/deflists_object.rb
+++ b/examples/deflists_object.rb
@@ -17,7 +17,7 @@ def self.bullet_list(items)
   PandocElement::BulletList.new(items)
 end
 
-PandocElement.filter do |element|
+PandocElement.filter! do |element|
   if element.kind_of?(PandocElement::DefinitionList)
     bullet_list(element.elements)
   end

--- a/examples/deflists_object.rb
+++ b/examples/deflists_object.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+require 'pandoc-filter'
+
+def self.tobullet(term, defs)
+  elements = [ PandocElement::Para.new([PandocElement::Strong.new(term)]) ]
+  defs.each do |el|
+    el.each do |el_el|
+      elements.push(el_el)
+    end
+  end
+  return elements
+end
+
+def self.bullet_list(items)
+  items = items.map{|item| tobullet(item[0],item[1])}
+  PandocElement::BulletList.new(items)
+end
+
+PandocElement.filter do |element|
+  if element.kind_of?(PandocElement::DefinitionList)
+    bullet_list(element.elements)
+  end
+end

--- a/examples/format-sample.md
+++ b/examples/format-sample.md
@@ -1,0 +1,1 @@
+This document was converted to %{format}

--- a/examples/format.rb
+++ b/examples/format.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+# Pandoc filter to allow inserting the format that the document was formatted
+# to. %{format} will be replaced by the format that pandoc passes in to this
+# filter. It will only be replaced from matching Str elements.
+
+require 'pandoc-filter'
+
+PandocFilter.filter do |type,value,format,meta|
+  if type == 'Str' && value == '%{format}'
+    PandocElement.Str(format)
+  end
+end

--- a/examples/format_object.rb
+++ b/examples/format_object.rb
@@ -11,6 +11,5 @@ filter = PandocElement::Filter.new
 filter.filter do |element|
   if element.kind_of?(PandocElement::Str) && element.value == '%{format}'
     element.value = filter.format
-    element
   end
 end

--- a/examples/format_object.rb
+++ b/examples/format_object.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+# Pandoc filter to allow inserting the format that the document was formatted
+# to. %{format} will be replaced by the format that pandoc passes in to this
+# filter. It will only be replaced from matching Str elements.
+
+require 'pandoc-filter'
+
+filter = PandocElement::Filter.new
+
+filter.filter do |element|
+  if element.kind_of?(PandocElement::Str) && element.value == '%{format}'
+    element.value = filter.format
+    element
+  end
+end

--- a/examples/metavars-sample.md
+++ b/examples/metavars-sample.md
@@ -1,0 +1,7 @@
+---
+author: Caleb Hyde
+---
+
+# %{author}
+
+This was written by %{author}

--- a/examples/metavars.rb
+++ b/examples/metavars.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+# Pandoc filter to allow interpolation of metadata fields
+# into a document.  %{fields} will be replaced by the field's
+# value, assuming it is of the type MetaInlines or MetaString.
+
+require 'pandoc-filter'
+
+PandocFilter.filter do |type,value,format,meta|
+  if type == 'Str'
+    match = /%\{(.*)\}$/.match(value)
+
+    if match
+      field = match[1]
+      result = meta[field]
+
+      if result['t'] == 'MetaInlines'
+        next PandocElement.Span(['', ['interpolated'], [['field', field]]], result['c'])
+      elsif result['t'] == 'MetaString'
+        next PandocElement.Str(result['c'])
+      end
+    end
+  end
+end

--- a/examples/metavars_object.rb
+++ b/examples/metavars_object.rb
@@ -6,18 +6,20 @@
 
 require 'pandoc-filter'
 
-PandocElement.filter do |element|
+filter = PandocElement::Filter.new
+
+filter.filter do |element|
   if element.kind_of?(PandocElement::Str)
     match = /%\{(.*)\}$/.match(element.value)
 
     if match
       field = match[1]
-      result = meta[field]
+      result = filter.meta[field]
 
-      if result['t'] == 'MetaInlines'
-        next PandocElement.Span(['', ['interpolated'], [['field', field]]], result['c'])
-      elsif result['t'] == 'MetaString'
-        next PandocElement.Str(result['c'])
+      if result.kind_of?(PandocElement::MetaInlines)
+        next PandocElement::Span.new([PandocElement::Attr.build(classes: ['interpolated'], key_values: { 'field' => field }), result.elements])
+      elsif result.kind_of?(PandocElement::MetaString)
+        next PandocElement.Str(result.value)
       end
     end
   end

--- a/examples/metavars_object.rb
+++ b/examples/metavars_object.rb
@@ -8,7 +8,7 @@ require 'pandoc-filter'
 
 filter = PandocElement::Filter.new
 
-filter.filter do |element|
+filter.filter! do |element|
   if element.kind_of?(PandocElement::Str)
     match = /%\{(.*)\}$/.match(element.value)
 

--- a/examples/metavars_object.rb
+++ b/examples/metavars_object.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+# Pandoc filter to allow interpolation of metadata fields
+# into a document.  %{fields} will be replaced by the field's
+# value, assuming it is of the type MetaInlines or MetaString.
+
+require 'pandoc-filter'
+
+PandocElement.filter do |element|
+  if element.kind_of?(PandocElement::Str)
+    match = /%\{(.*)\}$/.match(element.value)
+
+    if match
+      field = match[1]
+      result = meta[field]
+
+      if result['t'] == 'MetaInlines'
+        next PandocElement.Span(['', ['interpolated'], [['field', field]]], result['c'])
+      elsif result['t'] == 'MetaString'
+        next PandocElement.Str(result['c'])
+      end
+    end
+  end
+end

--- a/lib/pandoc-filter.rb
+++ b/lib/pandoc-filter.rb
@@ -68,7 +68,7 @@ module PandocElement
     ['Div', 2],
     ['Null', 0],
     ['Str', 1],
-    ['Emp', 1],
+    ['Emph', 1],
     ['Strong', 1],
     ['Strikeout', 1],
     ['Superscript', 1],
@@ -78,11 +78,12 @@ module PandocElement
     ['Cite', 2],
     ['Code', 2],
     ['Space', 0],
+    ['SoftBreak', 0],
     ['LineBreak', 0],
     ['Math', 2],
     ['RawInline', 2],
-    ['Link', 2],
-    ['Image', 2],
+    ['Link', 3],
+    ['Image', 3],
     ['Note', 1],
     ['Span', 2]
   ].each do |name, params|

--- a/lib/pandoc-filter.rb
+++ b/lib/pandoc-filter.rb
@@ -106,7 +106,7 @@ module PandocElement
   end
 
   class Filter
-    attr_accessor :format, :meta
+    attr_accessor :doc, :format, :meta
 
     def initialize(input = $stdin, output = $stdout, &block)
       @input = input
@@ -114,11 +114,12 @@ module PandocElement
       @block = block
     end
 
-    def filter
-      doc = PandocElement::Document.new(JSON.parse(@input.read))
+    def filter(&block)
+      @block = block unless @block
+      @doc = PandocElement::Document.new(JSON.parse(@input.read))
       @format = ARGV.first
-      @meta = doc.meta
-      result = PandocElement.walk!(doc, &@block)
+      @meta = @doc.meta
+      result = PandocElement.walk!(@doc, &@block)
       @output.puts JSON.dump(PandocElement.to_ast(result))
     end
   end

--- a/lib/pandoc-filter.rb
+++ b/lib/pandoc-filter.rb
@@ -74,7 +74,7 @@ module PandocElement
     elsif object.kind_of?(Hash) && object.include?('t') && object.include?('c')
       raise "Unknown type: #{object['t']}" unless PandocElement.const_defined?(object['t'])
       type = PandocElement.const_get(object['t'])
-      raise "Invalid type: #{object['t']}" unless type < PandocElement::Base
+      raise "Invalid type: #{object['t']}" unless type < PandocElement::BaseElement
       type.new(to_object(object['c']))
     elsif object.kind_of?(Hash)
       result = {}
@@ -88,12 +88,16 @@ module PandocElement
   class Base
     attr_reader :contents
 
+    def self.contents_attr(name, index)
+      define_method(name) { contents[index] }
+    end
+
     def initialize(contents = [])
       @contents = contents
     end
 
     def to_ast
-      { 't' => element_name, 'c' => PandocElement.to_ast(contents) }
+      PandocElement.to_ast(contents)
     end
 
     def ==(other)
@@ -101,40 +105,83 @@ module PandocElement
     end
   end
 
-  [ ['Plain', :elements],
-    ['Para', :elements],
-    ['CodeBlock', :attributes, :value],
-    ['RawBlock', :format, :value],
-    ['BlockQuote', :elements],
-    ['OrderedList', :attributes, :elements],
-    ['BulletList', :elements],
-    ['DefinitionList', :elements],
-    ['Header', :level, :attributes, :elements],
-    ['HorizontalRule'],
-    ['Table', :captions, :alignments, :widths, :headers, :rows],
-    ['Div', :attributes, :elements],
-    ['Null'],
-    ['Str', :value],
-    ['Emph', :elements],
-    ['Strong', :elements],
-    ['Strikeout', :elements],
-    ['Superscript', :elements],
-    ['Subscript', :elements],
-    ['SmallCaps', :elements],
-    ['Quoted', :type, :elements],
-    ['Cite', :citations, :elements],
-    ['Code', :attributes, :value],
-    ['Space'],
-    ['SoftBreak'],
-    ['LineBreak'],
-    ['Math', :type, :value],
-    ['RawInline', :format, :value],
-    ['Link', :attributes, :elements, :target],
-    ['Image', :attributes, :elements, :target],
-    ['Note', :elements],
-    ['Span', :attributes, :elements]
+  class BaseElement < PandocElement::Base
+    def to_ast
+      { 't' => element_name, 'c' => PandocElement.to_ast(contents) }
+    end
+  end
+
+  module Inline
+  end
+
+  module Block
+  end
+
+  class Attr < PandocElement::Base
+    contents_attr :identifier, 0
+    contents_attr :classes, 1
+    contents_attr :key_values, 2
+
+    def [](key)
+      key_values_hash[key]
+    end
+
+    def include?(key)
+      key_values_hash.include?(key)
+    end
+
+    private
+
+    def key_values_hash
+      @key_values_hash ||= Hash[key_values]
+    end
+  end
+
+  class Target < PandocElement::Base
+    contents_attr :url, 0
+    contents_attr :title, 1
+  end
+
+  [ ['Plain',          :elements,                                        { include: [PandocElement::Block] }],
+    ['Para',           :elements,                                        { include: [PandocElement::Block] }],
+    ['CodeBlock',      :attributes, :value,                              { include: [PandocElement::Block] }],
+    ['RawBlock',       :format, :value,                                  { include: [PandocElement::Block] }],
+    ['BlockQuote',     :elements,                                        { include: [PandocElement::Block] }],
+    ['OrderedList',    :attributes, :elements,                           { include: [PandocElement::Block] }],
+    ['BulletList',     :elements,                                        { include: [PandocElement::Block] }],
+    ['DefinitionList', :elements,                                        { include: [PandocElement::Block] }],
+    ['Header',         :level, :attributes, :elements,                   { include: [PandocElement::Block] }],
+    ['HorizontalRule',                                                   { include: [PandocElement::Block] }],
+    ['Table',          :captions, :alignments, :widths, :headers, :rows, { include: [PandocElement::Block] }],
+    ['Div',            :attributes, :elements,                           { include: [PandocElement::Block] }],
+    ['Null',                                                             { include: [PandocElement::Block] }],
+    ['Str',            :value,                                           { include: [PandocElement::Inline] }],
+    ['Emph',           :elements,                                        { include: [PandocElement::Inline] }],
+    ['Strong',         :elements,                                        { include: [PandocElement::Inline] }],
+    ['Strikeout',      :elements,                                        { include: [PandocElement::Inline] }],
+    ['Superscript',    :elements,                                        { include: [PandocElement::Inline] }],
+    ['Subscript',      :elements,                                        { include: [PandocElement::Inline] }],
+    ['SmallCaps',      :elements,                                        { include: [PandocElement::Inline] }],
+    ['Quoted',         :type, :elements,                                 { include: [PandocElement::Inline] }],
+    ['Cite',           :citations, :elements,                            { include: [PandocElement::Inline] }],
+    ['Code',           :attributes, :value,                              { include: [PandocElement::Inline] }],
+    ['Space',                                                            { include: [PandocElement::Inline] }],
+    ['SoftBreak',                                                        { include: [PandocElement::Inline] }],
+    ['LineBreak',                                                        { include: [PandocElement::Inline] }],
+    ['Math',           :type, :value,                                    { include: [PandocElement::Inline] }],
+    ['RawInline',      :format, :value,                                  { include: [PandocElement::Inline] }],
+    ['Link',           :attributes, :elements, :target,                  { include: [PandocElement::Inline] }],
+    ['Image',          :attributes, :elements, :target,                  { include: [PandocElement::Inline] }],
+    ['Note',           :elements,                                        { include: [PandocElement::Inline] }],
+    ['Span',           :attributes, :elements,                           { include: [PandocElement::Inline] }]
   ].each do |name, *params|
     name.freeze
+
+    options = if params.last.kind_of?(Hash)
+      params.pop
+    else
+      {}
+    end
 
     case params.size
     when 0
@@ -153,11 +200,13 @@ module PandocElement
       raise "Too many parameters!"
     end
 
-    const_set(name, Class.new(PandocElement::Base) {
+    const_set(name, Class.new(PandocElement::BaseElement) {
+      (options[:include] || []).each { |mod| include mod }
+
       if params.size == 1
         define_method(params.first) { contents }
       else
-        params.each_with_index { |param, index| define_method(param) { contents[index] } }
+        params.each_with_index { |param, index| contents_attr param, index }
       end
 
       define_method(:element_name) { name }

--- a/lib/pandoc-filter.rb
+++ b/lib/pandoc-filter.rb
@@ -8,16 +8,16 @@ require 'json'
 
 module PandocFilter
 
-  def self.filter(&block)
+  def self.filter(input = $stdin, output = $stdout, &block)
     # maybe not the right call?
-    doc = JSON.parse($stdin.read)
+    doc = JSON.parse(input.read)
     format = nil
     if ARGV.length > 1
       @format = ARGV[1]
     end
     @block = block
     @meta = doc[0]['unMeta']
-    $stdout.puts JSON.dump(walk(doc))
+    output.puts JSON.dump(walk(doc))
   end
 
   def self.walk(x)

--- a/lib/pandoc-filter.rb
+++ b/lib/pandoc-filter.rb
@@ -9,19 +9,20 @@ require 'json'
 class PandocFilter
   attr_accessor :format, :meta
 
-  def initialize(input = $stdin, output = $stdout, &block)
+  def initialize(input = $stdin, output = $stdout, argv = ARGV, &block)
     @input = input
     @output = output
+    @argv = argv
     @block = block
   end
 
-  def self.filter(input = $stdin, output = $stdout, &block)
-    new(input, output, &block).filter
+  def self.filter(input = $stdin, output = $stdout, argv = ARGV, &block)
+    new(input, output, argv, &block).filter
   end
 
   def filter
     doc = JSON.parse(@input.read)
-    @format = ARGV.first
+    @format = @argv.first
     @meta = doc[0]['unMeta']
     @output.puts JSON.dump(walk(doc))
   end
@@ -101,23 +102,24 @@ module PandocElement
     PandocElement::Walker.new(object, &block).walk!
   end
 
-  def self.filter(input = $stdin, output = $stdout, &block)
-    PandocElement::Filter.new(input, output, &block).filter
+  def self.filter(input = $stdin, output = $stdout, argv = ARGV, &block)
+    PandocElement::Filter.new(input, output, argv, &block).filter
   end
 
   class Filter
     attr_accessor :doc, :format, :meta
 
-    def initialize(input = $stdin, output = $stdout, &block)
+    def initialize(input = $stdin, output = $stdout, argv = ARGV, &block)
       @input = input
       @output = output
+      @argv = argv
       @block = block
     end
 
     def filter(&block)
       @block = block unless @block
       @doc = PandocElement::Document.new(JSON.parse(@input.read))
-      @format = ARGV.first
+      @format = @argv.first
       @meta = @doc.meta
       result = PandocElement.walk!(@doc, &@block)
       @output.puts JSON.dump(PandocElement.to_ast(result))

--- a/lib/pandoc-filter.rb
+++ b/lib/pandoc-filter.rb
@@ -99,6 +99,28 @@ module PandocElement
     PandocElement::Walker.new(object, &block).walk!
   end
 
+  def self.filter(input = $stdin, output = $stdout, &block)
+    PandocElement::Filter.new(input, output, &block).filter
+  end
+
+  class Filter
+    attr_accessor :format, :meta
+
+    def initialize(input = $stdin, output = $stdout, &block)
+      @input = input
+      @output = output
+      @block = block
+    end
+
+    def filter
+      doc = PandocElement.to_object(JSON.parse(@input.read))
+      @format = ARGV.first
+      @meta = doc[0]['unMeta']
+      result = PandocElement.walk!(doc, &@block)
+      @output.puts JSON.dump(PandocElement.to_ast(result))
+    end
+  end
+
   class Walker
     def initialize(object, &block)
       @object = object

--- a/lib/pandoc-filter.rb
+++ b/lib/pandoc-filter.rb
@@ -6,21 +6,27 @@
 
 require 'json'
 
-module PandocFilter
+class PandocFilter
+  attr_accessor :format, :meta
 
-  def self.filter(input = $stdin, output = $stdout, &block)
-    # maybe not the right call?
-    doc = JSON.parse(input.read)
-    format = nil
-    if ARGV.length > 1
-      @format = ARGV[1]
-    end
+  def initialize(input = $stdin, output = $stdout, &block)
+    @input = input
+    @output = output
     @block = block
-    @meta = doc[0]['unMeta']
-    output.puts JSON.dump(walk(doc))
   end
 
-  def self.walk(x)
+  def self.filter(input = $stdin, output = $stdout, &block)
+    new(input, output, &block).filter
+  end
+
+  def filter
+    doc = JSON.parse(@input.read)
+    @format = ARGV.first
+    @meta = doc[0]['unMeta']
+    @output.puts JSON.dump(walk(doc))
+  end
+
+  def walk(x)
     if x.kind_of?(Array)
       result = []
       x.each do |item|

--- a/pandoc-filter.gemspec
+++ b/pandoc-filter.gemspec
@@ -9,4 +9,5 @@ Gem::Specification.new do |s|
   s.files       = ['lib/pandoc-filter.rb']
   s.homepage    = 'https://github.com/karaken12/pandoc-filters-ruby'
   s.license     = 'MIT'
+  s.add_development_dependency 'minitest', '~> 5.9'
 end

--- a/test/all.rb
+++ b/test/all.rb
@@ -1,0 +1,1 @@
+Dir[File.expand_path('../*_test.rb', __FILE__)].each { |file| puts file; require file }

--- a/test/ast_test.rb
+++ b/test/ast_test.rb
@@ -1,0 +1,59 @@
+require_relative 'test_helper'
+
+class AstTest < Minitest::Test
+  def test_space
+    assert_equal({ 't' => 'Space', 'c' => [] }, PandocElement::Space.new.to_ast)
+  end
+
+  def test_str
+    assert_equal({ 't' => 'Str', 'c' => 'hello' }, PandocElement::Str.new('hello').to_ast)
+  end
+
+  def test_to_ast_with_object
+    assert_equal({ 't' => 'Space', 'c' => [] }, PandocElement.to_ast(PandocElement::Space.new))
+  end
+
+  def test_to_ast_with_array
+    expected = [
+      { 't' => 'Str', 'c' => 'hello' },
+      { 't' => 'Space', 'c' => [] },
+      { 't' => 'Str', 'c' => 'world' }
+    ]
+
+    actual = PandocElement.to_ast([
+      PandocElement::Str.new('hello'),
+      PandocElement::Space.new,
+      PandocElement::Str.new('world')
+    ])
+
+    assert_equal(expected, actual)
+  end
+
+  def test_to_ast_with_hash
+    expected = { 'x' => 'value', 'y' => { 't' => 'Space', 'c' => [] } }
+    actual = PandocElement.to_ast('x' => 'value', 'y' => PandocElement::Space.new)
+    assert_equal(expected, actual)
+  end
+
+  def test_to_ast_with_string
+    assert_equal('hello', PandocElement.to_ast('hello'))
+  end
+
+  def test_para
+    expected = {
+      't' => 'Para', 'c' => [
+        { 't' => 'Str', 'c' => 'hello' },
+        { 't' => 'Space', 'c' => [] },
+        { 't' => 'Str', 'c' => 'world' }
+      ]
+    }
+
+    actual = PandocElement::Para.new([
+      PandocElement::Str.new('hello'),
+      PandocElement::Space.new,
+      PandocElement::Str.new('world')
+    ]).to_ast
+
+    assert_equal(expected, actual)
+  end
+end

--- a/test/basic_filters_test.rb
+++ b/test/basic_filters_test.rb
@@ -1,0 +1,62 @@
+require_relative 'test_helper'
+
+class BasicFiltersTest < Minitest::Test
+  include PandocHelper
+
+  def test_filter_that_does_nothing
+    ast = to_pandoc_ast <<-EOF
+      # Header
+
+      This is a paragraph
+
+      # Another Header
+
+      This is a paragraph *with emphasis*
+    EOF
+
+    output = StringIO.new
+    PandocFilter.filter(ast_to_stream(ast), output) { }
+    assert_equal(ast, stream_to_ast(output))
+  end
+
+  def test_filter_to_affect_headers
+    ast = to_pandoc_ast <<-EOF
+      # Header
+
+      This is a paragraph
+
+      # Another Header
+
+      This is a paragraph *with emphasis*
+    EOF
+
+    output = StringIO.new
+
+    PandocFilter.filter(ast_to_stream(ast), output) do |type, value, _format, _meta|
+      next unless type == 'Header'
+      PandocElement.Header(value[0], value[1], value[2].map { |node| upcase_if_str_node(node) })
+    end
+
+    expected_ast = to_pandoc_ast <<-EOF
+      # HEADER
+
+      This is a paragraph
+
+      # ANOTHER HEADER
+
+      This is a paragraph *with emphasis*
+    EOF
+
+    assert_equal(expected_ast, stream_to_ast(output))
+  end
+
+  private
+
+  def upcase_if_str_node(node)
+    if node['t'] == 'Str'
+      PandocElement.Str(node['c'].upcase)
+    else
+      node
+    end
+  end
+end

--- a/test/basic_walk_test.rb
+++ b/test/basic_walk_test.rb
@@ -1,0 +1,82 @@
+require_relative 'test_helper'
+
+class BasicWalkTest < Minitest::Test
+  include PandocHelper
+
+  def setup
+    @types = []
+    @values = []
+  end
+
+  def test_walk_of_single_element
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; nil }
+    result = filter.walk(ast('Str', 'hello'))
+    assert_empty(@types)
+    assert_empty(@values)
+    assert_equal(ast('Str', 'hello'), result)
+  end
+
+  def test_walk_of_array_of_elements
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; nil }
+    result = filter.walk([ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])
+    assert_equal(['Str', 'Space', 'Str'], @types)
+    assert_equal(['hello', [], 'world'], @values)
+    assert_equal([ast('Str', 'hello'), ast('Space'), ast('Str', 'world')], result)
+  end
+
+  def test_walk_of_hash_of_elements
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; nil }
+    result = filter.walk('x' => [ast('Space')], 'y' => [ast('SoftBreak')], 'z' => [ast('Null')])
+    assert_equal(['Space', 'SoftBreak', 'Null'], @types)
+    assert_equal([[], [], []], @values)
+    assert_equal({ 'x' => [ast('Space')], 'y' => [ast('SoftBreak')], 'z' => [ast('Null')] }, result)
+  end
+
+  def test_nested_walk
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; nil }
+    result = filter.walk([ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])])
+    assert_equal(['Para', 'Str', 'Space', 'Str'], @types)
+    assert_equal([[ast('Str', 'hello'), ast('Space'), ast('Str', 'world')], 'hello', [], 'world'], @values)
+    assert_equal([ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])], result)
+  end
+
+  def test_walk_replacing_certain_elements
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; ast('Space') if type == 'Str' }
+    result = filter.walk([ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])])
+    assert_equal(['Para', 'Str', 'Space', 'Str'], @types)
+    assert_equal([[ast('Str', 'hello'), ast('Space'), ast('Str', 'world')], 'hello', [], 'world'], @values)
+    assert_equal([ast('Para', [ast('Space'), ast('Space'), ast('Space')])], result)
+  end
+
+  def test_walk_replacing_certain_elements_with_nested_elements
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; ast('Plain', [ast('SoftBreak')]) if type == 'Str' }
+    result = filter.walk([ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])])
+    assert_equal(['Para', 'Str', 'SoftBreak', 'Space', 'Str', 'SoftBreak'], @types)
+    assert_equal([[ast('Str', 'hello'), ast('Space'), ast('Str', 'world')], 'hello', [], [], 'world', []], @values)
+    assert_equal([ast('Para', [ast('Plain', [ast('SoftBreak')]), ast('Space'), ast('Plain', [ast('SoftBreak')])])], result)
+  end
+
+  def test_walk_of_hash_of_elements_replacing_some_elements
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; ast('LineBreak') if type == 'Null' }
+    result = filter.walk('x' => [ast('Space')], 'y' => [ast('SoftBreak')], 'z' => [ast('Null')])
+    assert_equal(['Space', 'SoftBreak', 'Null'], @types)
+    assert_equal([[], [], []], @values)
+    assert_equal({ 'x' => [ast('Space')], 'y' => [ast('SoftBreak')], 'z' => [ast('LineBreak')] }, result)
+  end
+
+  def test_walk_and_remove_element
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; [] if type == 'Str' }
+    result = filter.walk([ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])])
+    assert_equal(['Para', 'Str', 'Space', 'Str'], @types)
+    assert_equal([[ast('Str', 'hello'), ast('Space'), ast('Str', 'world')], 'hello', [], 'world'], @values)
+    assert_equal([ast('Para', [ast('Space')])], result)
+  end
+
+  def test_walk_and_add_elements
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; [ast('LineBreak'), ast(type, value)] if type == 'Str' }
+    result = filter.walk([ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])])
+    assert_equal(['Para', 'Str', 'Space', 'Str'], @types)
+    assert_equal([[ast('Str', 'hello'), ast('Space'), ast('Str', 'world')], 'hello', [], 'world'], @values)
+    assert_equal([ast('Para', [ast('LineBreak'), ast('Str', 'hello'), ast('Space'), ast('LineBreak'), ast('Str', 'world')])], result)
+  end
+end

--- a/test/basic_walk_test.rb
+++ b/test/basic_walk_test.rb
@@ -2,6 +2,7 @@ require_relative 'test_helper'
 
 class BasicWalkTest < Minitest::Test
   include PandocHelper
+  include PandocAstHelper
 
   def setup
     @types = []
@@ -10,73 +11,73 @@ class BasicWalkTest < Minitest::Test
 
   def test_walk_of_single_element
     filter = PandocFilter.new { |type, value| @types << type; @values << value; nil }
-    result = filter.walk(ast('Str', 'hello'))
+    result = filter.walk(hello_str_ast)
     assert_empty(@types)
     assert_empty(@values)
-    assert_equal(ast('Str', 'hello'), result)
+    assert_equal(hello_str_ast, result)
   end
 
   def test_walk_of_array_of_elements
     filter = PandocFilter.new { |type, value| @types << type; @values << value; nil }
-    result = filter.walk([ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])
+    result = filter.walk([hello_str_ast, space_ast, world_str_ast])
     assert_equal(['Str', 'Space', 'Str'], @types)
     assert_equal(['hello', [], 'world'], @values)
-    assert_equal([ast('Str', 'hello'), ast('Space'), ast('Str', 'world')], result)
+    assert_equal([hello_str_ast, space_ast, world_str_ast], result)
   end
 
   def test_walk_of_hash_of_elements
     filter = PandocFilter.new { |type, value| @types << type; @values << value; nil }
-    result = filter.walk('x' => [ast('Space')], 'y' => [ast('SoftBreak')], 'z' => [ast('Null')])
+    result = filter.walk('x' => [space_ast], 'y' => [soft_break_ast], 'z' => [null_ast])
     assert_equal(['Space', 'SoftBreak', 'Null'], @types)
     assert_equal([[], [], []], @values)
-    assert_equal({ 'x' => [ast('Space')], 'y' => [ast('SoftBreak')], 'z' => [ast('Null')] }, result)
+    assert_equal({ 'x' => [space_ast], 'y' => [soft_break_ast], 'z' => [null_ast] }, result)
   end
 
   def test_nested_walk
     filter = PandocFilter.new { |type, value| @types << type; @values << value; nil }
-    result = filter.walk([ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])])
+    result = filter.walk([para_ast(hello_str_ast, space_ast, world_str_ast)])
     assert_equal(['Para', 'Str', 'Space', 'Str'], @types)
-    assert_equal([[ast('Str', 'hello'), ast('Space'), ast('Str', 'world')], 'hello', [], 'world'], @values)
-    assert_equal([ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])], result)
+    assert_equal([[hello_str_ast, space_ast, world_str_ast], 'hello', [], 'world'], @values)
+    assert_equal([para_ast(hello_str_ast, space_ast, world_str_ast)], result)
   end
 
   def test_walk_replacing_certain_elements
-    filter = PandocFilter.new { |type, value| @types << type; @values << value; ast('Space') if type == 'Str' }
-    result = filter.walk([ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])])
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; space_ast if type == 'Str' }
+    result = filter.walk([para_ast(hello_str_ast, space_ast, world_str_ast)])
     assert_equal(['Para', 'Str', 'Space', 'Str'], @types)
-    assert_equal([[ast('Str', 'hello'), ast('Space'), ast('Str', 'world')], 'hello', [], 'world'], @values)
-    assert_equal([ast('Para', [ast('Space'), ast('Space'), ast('Space')])], result)
+    assert_equal([[hello_str_ast, space_ast, world_str_ast], 'hello', [], 'world'], @values)
+    assert_equal([para_ast(space_ast, space_ast, space_ast)], result)
   end
 
   def test_walk_replacing_certain_elements_with_nested_elements
-    filter = PandocFilter.new { |type, value| @types << type; @values << value; ast('Plain', [ast('SoftBreak')]) if type == 'Str' }
-    result = filter.walk([ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])])
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; plain_ast(soft_break_ast) if type == 'Str' }
+    result = filter.walk([para_ast(hello_str_ast, space_ast, world_str_ast)])
     assert_equal(['Para', 'Str', 'SoftBreak', 'Space', 'Str', 'SoftBreak'], @types)
-    assert_equal([[ast('Str', 'hello'), ast('Space'), ast('Str', 'world')], 'hello', [], [], 'world', []], @values)
-    assert_equal([ast('Para', [ast('Plain', [ast('SoftBreak')]), ast('Space'), ast('Plain', [ast('SoftBreak')])])], result)
+    assert_equal([[hello_str_ast, space_ast, world_str_ast], 'hello', [], [], 'world', []], @values)
+    assert_equal([para_ast(plain_ast(soft_break_ast), space_ast, plain_ast(soft_break_ast))], result)
   end
 
   def test_walk_of_hash_of_elements_replacing_some_elements
-    filter = PandocFilter.new { |type, value| @types << type; @values << value; ast('LineBreak') if type == 'Null' }
-    result = filter.walk('x' => [ast('Space')], 'y' => [ast('SoftBreak')], 'z' => [ast('Null')])
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; line_break_ast if type == 'Null' }
+    result = filter.walk('x' => [space_ast], 'y' => [soft_break_ast], 'z' => [null_ast])
     assert_equal(['Space', 'SoftBreak', 'Null'], @types)
     assert_equal([[], [], []], @values)
-    assert_equal({ 'x' => [ast('Space')], 'y' => [ast('SoftBreak')], 'z' => [ast('LineBreak')] }, result)
+    assert_equal({ 'x' => [space_ast], 'y' => [soft_break_ast], 'z' => [line_break_ast] }, result)
   end
 
   def test_walk_and_remove_element
     filter = PandocFilter.new { |type, value| @types << type; @values << value; [] if type == 'Str' }
-    result = filter.walk([ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])])
+    result = filter.walk([para_ast(hello_str_ast, space_ast, world_str_ast)])
     assert_equal(['Para', 'Str', 'Space', 'Str'], @types)
-    assert_equal([[ast('Str', 'hello'), ast('Space'), ast('Str', 'world')], 'hello', [], 'world'], @values)
-    assert_equal([ast('Para', [ast('Space')])], result)
+    assert_equal([[hello_str_ast, space_ast, world_str_ast], 'hello', [], 'world'], @values)
+    assert_equal([para_ast(space_ast)], result)
   end
 
   def test_walk_and_add_elements
-    filter = PandocFilter.new { |type, value| @types << type; @values << value; [ast('LineBreak'), ast(type, value)] if type == 'Str' }
-    result = filter.walk([ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])])
+    filter = PandocFilter.new { |type, value| @types << type; @values << value; [line_break_ast, ast(type, value)] if type == 'Str' }
+    result = filter.walk([para_ast(hello_str_ast, space_ast, world_str_ast)])
     assert_equal(['Para', 'Str', 'Space', 'Str'], @types)
-    assert_equal([[ast('Str', 'hello'), ast('Space'), ast('Str', 'world')], 'hello', [], 'world'], @values)
-    assert_equal([ast('Para', [ast('LineBreak'), ast('Str', 'hello'), ast('Space'), ast('LineBreak'), ast('Str', 'world')])], result)
+    assert_equal([[hello_str_ast, space_ast, world_str_ast], 'hello', [], 'world'], @values)
+    assert_equal([para_ast(line_break_ast, hello_str_ast, space_ast, line_break_ast, world_str_ast)], result)
   end
 end

--- a/test/change_attributes_test.rb
+++ b/test/change_attributes_test.rb
@@ -1,0 +1,88 @@
+require_relative 'test_helper'
+
+class ChangeAttributesTest < Minitest::Test
+  include PandocHelper
+
+  def test_str
+    str = PandocElement::Str.new('hello')
+    str.value.upcase!
+    assert_equal(ast('Str', 'HELLO'), str.to_ast)
+    str.value = 'world'
+    assert_equal(ast('Str', 'world'), str.to_ast)
+  end
+
+  def test_para
+    para = PandocElement::Para.new([
+      PandocElement::Str.new('hello'),
+      PandocElement::Space.new,
+      PandocElement::Str.new('world')
+    ])
+
+    para.elements.pop
+    assert_equal(ast('Para', [ast('Str', 'hello'), ast('Space')]), para.to_ast)
+    para.elements = [PandocElement::Str.new('goodnight')]
+    assert_equal(ast('Para', [ast('Str', 'goodnight')]), para.to_ast)
+  end
+
+  def test_link
+    link = PandocElement::Link.new([
+      PandocElement::Attr.new(['id', ['class1', 'class2'], [['key1', 'value1'], ['key2', 'value2']]]),
+      [PandocElement::Str.new('link')],
+      PandocElement::Target.new(['http://example.com', 'This is the title'])
+    ])
+
+    link.attributes.identifier = 'new-id'
+    assert_equal(ast('Link', [['new-id', ['class1', 'class2'], [['key1', 'value1'], ['key2', 'value2']]], [ast('Str', 'link')], ['http://example.com', 'This is the title']]), link.to_ast)
+
+    link.attributes.classes = ['class1']
+    assert_equal(ast('Link', [['new-id', ['class1'], [['key1', 'value1'], ['key2', 'value2']]], [ast('Str', 'link')], ['http://example.com', 'This is the title']]), link.to_ast)
+
+    link.attributes = PandocElement::Attr.new(['new-id', ['class1'], [['key3', 'value3']]])
+    assert_equal(ast('Link', [['new-id', ['class1'], [['key3', 'value3']]], [ast('Str', 'link')], ['http://example.com', 'This is the title']]), link.to_ast)
+
+    link.target.url = 'http://alternate-example.com'
+    assert_equal(ast('Link', [['new-id', ['class1'], [['key3', 'value3']]], [ast('Str', 'link')], ['http://alternate-example.com', 'This is the title']]), link.to_ast)
+
+    link.target.title = 'New title'
+    assert_equal(ast('Link', [['new-id', ['class1'], [['key3', 'value3']]], [ast('Str', 'link')], ['http://alternate-example.com', 'New title']]), link.to_ast)
+
+    link.elements = [PandocElement::Str.new('new-link')]
+    assert_equal(ast('Link', [['new-id', ['class1'], [['key3', 'value3']]], [ast('Str', 'new-link')], ['http://alternate-example.com', 'New title']]), link.to_ast)
+  end
+
+  def test_attr_attributes_via_attribute_setters
+    attr = PandocElement::Attr.new(['id', ['class'], [['key1', 'value1'], ['key2', 'value2']]])
+    assert attr.include?('key1')
+    refute attr.include?('key3')
+    attr.key_values = [['key3', 'value3']]
+    assert_equal(['id', ['class'], [['key3', 'value3']]], attr.to_ast)
+    refute attr.include?('key1')
+    assert attr.include?('key3')
+  end
+
+  def test_attr_attributes_via_index_setter_with_missing_key
+    attr = PandocElement::Attr.new(['id', ['class'], [['key', 'value']]])
+    assert attr.include?('key')
+    refute attr.include?('key2')
+    attr['key2'] = 'value2'
+    assert_equal(['id', ['class'], [['key', 'value'], ['key2', 'value2']]], attr.to_ast)
+    assert attr.include?('key')
+    assert attr.include?('key2')
+  end
+
+  def test_attr_attributes_via_index_setter_with_single_key
+    attr = PandocElement::Attr.new(['id', ['class'], [['key', 'value']]])
+    assert attr.include?('key')
+    attr['key'] = 'value2'
+    assert_equal(['id', ['class'], [['key', 'value2']]], attr.to_ast)
+    assert attr.include?('key')
+  end
+
+  def test_attr_attributes_via_index_setter_with_duplicate_key
+    attr = PandocElement::Attr.new(['id', ['class'], [['key', 'value1'], ['key', 'value2']]])
+    assert attr.include?('key')
+    attr['key'] = 'value3'
+    assert_equal(['id', ['class'], [['key', 'value3'], ['key', 'value2']]], attr.to_ast)
+    assert attr.include?('key')
+  end
+end

--- a/test/change_attributes_test.rb
+++ b/test/change_attributes_test.rb
@@ -82,4 +82,21 @@ class ChangeAttributesTest < Minitest::Test
     assert_equal(['id', ['class'], [['key', 'value3'], ['key', 'value2']]], attr.to_ast)
     assert attr.include?('key')
   end
+
+  def test_build_attr
+    attr = PandocElement::Attr.build(identifier: 'id', classes: ['class'], key_values: [['key1', 'value1'], ['key2', 'value2']])
+    assert_equal(['id', ['class'], [['key1', 'value1'], ['key2', 'value2']]], attr.to_ast)
+  end
+
+  def test_build_attr_with_key_values_hash
+    attr = PandocElement::Attr.build(identifier: 'id', classes: ['class'], key_values: { 'key1' => 'value1', 'key2' => 'value2' })
+    assert_equal(['id', ['class'], [['key1', 'value1'], ['key2', 'value2']]], attr.to_ast)
+  end
+
+  def test_build_without_all_attributes
+    assert_equal(['', [], []], PandocElement::Attr.build().to_ast)
+    assert_equal(['id', [], []], PandocElement::Attr.build(identifier: 'id').to_ast)
+    assert_equal(['', ['class'], []], PandocElement::Attr.build(classes: ['class']).to_ast)
+    assert_equal(['', [], [['key', 'value']]], PandocElement::Attr.build(key_values: { 'key' => 'value' }).to_ast)
+  end
 end

--- a/test/change_attributes_test.rb
+++ b/test/change_attributes_test.rb
@@ -2,26 +2,23 @@ require_relative 'test_helper'
 
 class ChangeAttributesTest < Minitest::Test
   include PandocHelper
+  include PandocAstHelper
+  include PandocElementHelper
 
   def test_str
-    str = PandocElement::Str.new('hello')
+    str = hello_str
     str.value.upcase!
     assert_equal(ast('Str', 'HELLO'), str.to_ast)
     str.value = 'world'
-    assert_equal(ast('Str', 'world'), str.to_ast)
+    assert_equal(world_str_ast, str.to_ast)
   end
 
   def test_para
-    para = PandocElement::Para.new([
-      PandocElement::Str.new('hello'),
-      PandocElement::Space.new,
-      PandocElement::Str.new('world')
-    ])
-
+    para = para(hello_str, space, world_str)
     para.elements.pop
-    assert_equal(ast('Para', [ast('Str', 'hello'), ast('Space')]), para.to_ast)
+    assert_equal(para_ast(hello_str_ast, space_ast), para.to_ast)
     para.elements = [PandocElement::Str.new('goodnight')]
-    assert_equal(ast('Para', [ast('Str', 'goodnight')]), para.to_ast)
+    assert_equal(para_ast(ast('Str', 'goodnight')), para.to_ast)
   end
 
   def test_link

--- a/test/elements_test.rb
+++ b/test/elements_test.rb
@@ -4,12 +4,14 @@ class ElementsTest < Minitest::Test
   def test_space
     space = PandocElement::Space.new
     assert_equal([], space.contents)
+    assert space.kind_of?(PandocElement::Inline)
   end
 
   def test_str
     str = PandocElement::Str.new('hello')
     assert_equal('hello', str.contents)
     assert_equal('hello', str.value)
+    assert str.kind_of?(PandocElement::Inline)
   end
 
   def test_para
@@ -22,5 +24,27 @@ class ElementsTest < Minitest::Test
     para = PandocElement::Para.new(elements)
     assert_equal(elements, para.contents)
     assert_equal(elements, para.elements)
+    assert para.kind_of?(PandocElement::Block)
+  end
+
+  def test_link
+    link = PandocElement::Link.new([
+      PandocElement::Attr.new(['id', ['class1', 'class2'], [['key1', 'value1'], ['key2', 'value2']]]),
+      [PandocElement::Str.new('link')],
+      PandocElement::Target.new(['http://example.com', 'This is the title'])
+    ])
+
+    assert_equal('id', link.attributes.identifier)
+    assert_equal(['class1', 'class2'], link.attributes.classes)
+    assert_equal([['key1', 'value1'], ['key2', 'value2']], link.attributes.key_values)
+    assert_equal('value1', link.attributes['key1'])
+    assert_equal('value2', link.attributes['key2'])
+    assert_equal(nil, link.attributes['key3'])
+    assert_equal(true, link.attributes.include?('key1'))
+    assert_equal(true, link.attributes.include?('key2'))
+    assert_equal(false, link.attributes.include?('key3'))
+    assert_equal([PandocElement::Str.new('link')], link.elements)
+    assert_equal('http://example.com', link.target.url)
+    assert_equal('This is the title', link.target.title)
   end
 end

--- a/test/elements_test.rb
+++ b/test/elements_test.rb
@@ -1,0 +1,26 @@
+require_relative 'test_helper'
+
+class ElementsTest < Minitest::Test
+  def test_space
+    space = PandocElement::Space.new
+    assert_equal([], space.contents)
+  end
+
+  def test_str
+    str = PandocElement::Str.new('hello')
+    assert_equal('hello', str.contents)
+    assert_equal('hello', str.value)
+  end
+
+  def test_para
+    elements = [
+      PandocElement::Str.new('hello'),
+      PandocElement::Space.new,
+      PandocElement::Str.new('world')
+    ]
+
+    para = PandocElement::Para.new(elements)
+    assert_equal(elements, para.contents)
+    assert_equal(elements, para.elements)
+  end
+end

--- a/test/elements_test.rb
+++ b/test/elements_test.rb
@@ -1,27 +1,24 @@
 require_relative 'test_helper'
 
 class ElementsTest < Minitest::Test
+  include PandocElementHelper
+
   def test_space
-    space = PandocElement::Space.new
-    assert_equal([], space.contents)
-    assert space.kind_of?(PandocElement::Inline)
+    element = space
+    assert_equal([], element.contents)
+    assert element.kind_of?(PandocElement::Inline)
   end
 
   def test_str
-    str = PandocElement::Str.new('hello')
+    str = hello_str
     assert_equal('hello', str.contents)
     assert_equal('hello', str.value)
     assert str.kind_of?(PandocElement::Inline)
   end
 
   def test_para
-    elements = [
-      PandocElement::Str.new('hello'),
-      PandocElement::Space.new,
-      PandocElement::Str.new('world')
-    ]
-
-    para = PandocElement::Para.new(elements)
+    elements = [hello_str, space, world_str]
+    para = para(*elements)
     assert_equal(elements, para.contents)
     assert_equal(elements, para.elements)
     assert para.kind_of?(PandocElement::Block)

--- a/test/examples_test.rb
+++ b/test/examples_test.rb
@@ -114,6 +114,32 @@ class ExamplesTest < Minitest::Test
     EOF
 
     assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/metavars.rb", __FILE__)))
-    #assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/metavars_object.rb", __FILE__)))
+    assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/metavars_object.rb", __FILE__)))
+  end
+
+  def test_metavars_with_meta_string
+    doc = <<-EOF
+      ---
+      author: 42
+      ---
+
+      # %{author}
+
+      This was written by %{author}
+    EOF
+
+    expected_result = strip_whitespace <<-EOF
+      ---
+      author: 42
+      ...
+
+      42 {#author}
+      ==
+
+      This was written by 42
+    EOF
+
+    assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/metavars.rb", __FILE__)))
+    assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/metavars_object.rb", __FILE__)))
   end
 end

--- a/test/examples_test.rb
+++ b/test/examples_test.rb
@@ -89,4 +89,31 @@ class ExamplesTest < Minitest::Test
     assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/deflists.rb", __FILE__)))
     assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/deflists_object.rb", __FILE__)))
   end
+
+  def test_metavars
+    doc = <<-EOF
+      ---
+      author: Caleb Hyde
+      ---
+
+      # %{author}
+
+      This was written by %{author}
+    EOF
+
+    expected_result = strip_whitespace <<-EOF
+      ---
+      author: Caleb Hyde
+      ...
+
+      <span class="interpolated" field="author">Caleb Hyde</span> {#author}
+      ===========================================================
+
+      This was written by <span class="interpolated" field="author">Caleb
+      Hyde</span>
+    EOF
+
+    assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/metavars.rb", __FILE__)))
+    #assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/metavars_object.rb", __FILE__)))
+  end
 end

--- a/test/examples_test.rb
+++ b/test/examples_test.rb
@@ -142,4 +142,30 @@ class ExamplesTest < Minitest::Test
     assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/metavars.rb", __FILE__)))
     assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/metavars_object.rb", __FILE__)))
   end
+
+  def test_format_to_markdown
+    doc = <<-EOF
+      This document was converted to %{format}
+    EOF
+
+    expected_result = strip_whitespace <<-EOF
+      This document was converted to markdown
+    EOF
+
+    assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/format.rb", __FILE__)))
+    assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/format_object.rb", __FILE__)))
+  end
+
+  def test_format_to_markdown_github
+    doc = <<-EOF
+      This document was converted to %{format}
+    EOF
+
+    expected_result = strip_whitespace <<-EOF
+      This document was converted to markdown\\_github
+    EOF
+
+    assert_equal(expected_result, pandoc(doc, to: "markdown_github", filter: File.expand_path("../../examples/format.rb", __FILE__)))
+    assert_equal(expected_result, pandoc(doc, to: "markdown_github", filter: File.expand_path("../../examples/format_object.rb", __FILE__)))
+  end
 end

--- a/test/examples_test.rb
+++ b/test/examples_test.rb
@@ -1,0 +1,92 @@
+# coding: utf-8
+require_relative 'test_helper'
+
+class ExamplesTest < Minitest::Test
+  include PandocHelper
+
+  def test_caps
+    doc = <<-EOF
+      This is the caps sample with Äüö.
+    EOF
+
+    expected_result = strip_whitespace <<-EOF
+      THIS IS THE CAPS SAMPLE WITH Äüö.
+    EOF
+
+    assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/caps.rb", __FILE__)))
+    assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/caps_object.rb", __FILE__)))
+  end
+
+  def test_comments
+    doc = <<-EOF
+      Regular text with Äüö.
+
+      <!-- BEGIN COMMENT -->
+
+      This is a comment with Äüö
+
+      <!-- END COMMENT -->
+
+      This is regular text again.
+    EOF
+
+    expected_result = strip_whitespace <<-EOF
+      Regular text with Äüö.
+
+      This is regular text again.
+    EOF
+
+    assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/comments.rb", __FILE__)))
+    assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/comments_object.rb", __FILE__)))
+  end
+
+  def test_deflists
+    doc = <<-EOF
+      Some Definitions
+
+      Term 1
+
+      :   Definition 1
+
+      Term 2 with *inline markup*
+
+      :   Definition 2
+
+              { some code, part of Definition 2 }
+
+          Third paragraph of definition 2.
+
+      Term with Äüö
+
+      : Definition with Äüö
+
+
+      Regular Text.
+    EOF
+
+    expected_result = strip_whitespace <<-EOF
+      Some Definitions
+
+      -   **Term 1**
+
+          Definition 1
+
+      -   **Term 2 with *inline markup***
+
+          Definition 2
+
+              { some code, part of Definition 2 }
+
+          Third paragraph of definition 2.
+
+      -   **Term with Äüö**
+
+          Definition with Äüö
+
+      Regular Text.
+    EOF
+
+    assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/deflists.rb", __FILE__)))
+    assert_equal(expected_result, pandoc(doc, filter: File.expand_path("../../examples/deflists_object.rb", __FILE__)))
+  end
+end

--- a/test/meta_test.rb
+++ b/test/meta_test.rb
@@ -1,0 +1,113 @@
+require_relative 'test_helper'
+
+class MetaTest < Minitest::Test
+  include PandocAstHelper
+  include PandocHelper
+
+  def test_null
+    object = PandocElement::Document.new to_pandoc_ast(<<-EOF)
+      Contents
+    EOF
+
+    assert_equal PandocElement::Meta, object.meta.class
+    expected_ast = { 'unMeta' => {} }
+    assert_equal expected_ast, object.meta.to_ast
+  end
+
+  def test_empty
+    object = PandocElement::Document.new to_pandoc_ast(<<-EOF)
+      ---
+      ---
+      Contents
+    EOF
+
+    assert_equal PandocElement::Meta, object.meta.class
+    expected_ast = { 'unMeta' => {} }
+    assert_equal expected_ast, object.meta.to_ast
+  end
+
+  def test_string
+    object = PandocElement::Document.new to_pandoc_ast(<<-EOF)
+      ---
+      key: 123
+      ---
+      Contents
+    EOF
+
+    assert_equal PandocElement::MetaString, object.meta['key'].class
+    expected_ast = { 'unMeta' => { 'key' => ast('MetaString', '123') } }
+    assert_equal expected_ast, object.meta.to_ast
+  end
+
+  def test_bool
+    object = PandocElement::Document.new to_pandoc_ast(<<-EOF)
+      ---
+      key: true
+      ---
+      Contents
+    EOF
+
+    assert_equal PandocElement::MetaBool, object.meta['key'].class
+    expected_ast = { 'unMeta' => { 'key' => ast('MetaBool', true) } }
+    assert_equal expected_ast, object.meta.to_ast
+  end
+
+  def test_list
+    object = PandocElement::Document.new to_pandoc_ast(<<-EOF)
+      ---
+      key:
+      - 123
+      - 456
+      ---
+      Contents
+    EOF
+
+    assert_equal PandocElement::MetaList, object.meta['key'].class
+    expected_ast = { 'unMeta' => { 'key' => ast('MetaList', [ast('MetaString', '123'), ast('MetaString', '456')]) } }
+    assert_equal expected_ast, object.meta.to_ast
+  end
+
+  def test_map
+    object = PandocElement::Document.new to_pandoc_ast(<<-EOF)
+      ---
+      key:
+        key1: 123
+        key2: 456
+      ---
+      Contents
+    EOF
+
+    assert_equal PandocElement::MetaMap, object.meta['key'].class
+    expected_ast = { 'unMeta' => { 'key' => ast('MetaMap', { 'key1' => ast('MetaString', '123'), 'key2' => ast('MetaString', '456') }) } }
+    assert_equal expected_ast, object.meta.to_ast
+  end
+
+  def test_inlines
+    object = PandocElement::Document.new to_pandoc_ast(<<-EOF)
+      ---
+      key: hello world
+      ---
+      Contents
+    EOF
+
+    assert_equal PandocElement::MetaInlines, object.meta['key'].class
+    expected_ast = { 'unMeta' => { 'key' => ast('MetaInlines', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')]) } }
+    assert_equal expected_ast, object.meta.to_ast
+  end
+
+  def test_blocks
+    object = PandocElement::Document.new to_pandoc_ast(<<-EOF)
+      ---
+      key: |
+          <p>
+          Contents
+          </p>
+      ---
+      Contents
+    EOF
+
+    assert_equal PandocElement::MetaBlocks, object.meta['key'].class
+    expected_ast = { 'unMeta' => { 'key' => ast('MetaBlocks', [ast('RawBlock', ['html', '<p>']), ast('Plain', [ast('Str', 'Contents')]), ast('RawBlock', ['html', '</p>'])]) } }
+    assert_equal expected_ast, object.meta.to_ast
+  end
+end

--- a/test/object_filters_test.rb
+++ b/test/object_filters_test.rb
@@ -63,7 +63,6 @@ class ObjectFiltersTest < Minitest::Test
     filter.filter do |element|
       next unless element.kind_of?(PandocElement::Header)
       element.elements = [PandocElement::Str.new(filter.format)]
-      element
     end
 
     expected_ast = to_pandoc_ast <<-EOF
@@ -91,7 +90,6 @@ class ObjectFiltersTest < Minitest::Test
     filter.filter do |element|
       next unless element.kind_of?(PandocElement::Header)
       element.elements = filter.meta["header"].contents
-      element
     end
 
     expected_ast = to_pandoc_ast <<-EOF

--- a/test/object_filters_test.rb
+++ b/test/object_filters_test.rb
@@ -1,0 +1,52 @@
+require_relative 'test_helper'
+
+class ObjectFiltersTest < Minitest::Test
+  include PandocHelper
+
+  def test_filter_that_does_nothing
+    ast = to_pandoc_ast <<-EOF
+      # Header
+
+      This is a paragraph
+
+      # Another Header
+
+      This is a paragraph *with emphasis*
+    EOF
+
+    output = StringIO.new
+    PandocElement.filter(ast_to_stream(ast), output) { }
+    assert_equal(ast, stream_to_ast(output))
+  end
+
+  def test_filter_to_affect_headers
+    ast = to_pandoc_ast <<-EOF
+      # Header
+
+      This is a paragraph
+
+      # Another Header
+
+      This is a paragraph *with emphasis*
+    EOF
+
+    output = StringIO.new
+
+    PandocElement.filter(ast_to_stream(ast), output) do |element|
+      next unless element.kind_of?(PandocElement::Header)
+      element.walk { |e| e.value.upcase! if e.respond_to?(:value) }
+    end
+
+    expected_ast = to_pandoc_ast <<-EOF
+      # HEADER
+
+      This is a paragraph
+
+      # ANOTHER HEADER
+
+      This is a paragraph *with emphasis*
+    EOF
+
+    assert_equal(expected_ast, stream_to_ast(output))
+  end
+end

--- a/test/object_walk_bang_test.rb
+++ b/test/object_walk_bang_test.rb
@@ -1,0 +1,63 @@
+require_relative 'test_helper'
+
+class ObjectWalkBangTest < Minitest::Test
+  include PandocElementHelper
+
+  def setup
+    @elements = []
+  end
+
+  def test_walk_of_single_element
+    result = PandocElement.walk!(hello_str) { |element| @elements << element.dup; nil }
+    assert_empty(@elements)
+    assert_equal(hello_str, result)
+  end
+
+  def test_walk_of_array_of_elements
+    result = PandocElement.walk!([hello_str, space, world_str]) { |element| @elements << element.dup; nil }
+    assert_equal([hello_str, space, world_str], @elements)
+    assert_equal([hello_str, space, world_str], result)
+  end
+
+  def test_walk_of_hash_of_elements
+    result = PandocElement.walk!('x' => [space], 'y' => [soft_break], 'z' => [null]) { |element| @elements << element.dup; nil }
+    assert_equal([space, soft_break, null], @elements)
+    assert_equal({ 'x' => [space], 'y' => [soft_break], 'z' => [null] }, result)
+  end
+
+  def test_nested_walk
+    result = PandocElement.walk!([para(hello_str, space, world_str)]) { |element| @elements << element.dup; nil }
+    assert_equal([para(hello_str, space, world_str), hello_str, space, world_str], @elements)
+    assert_equal([para(hello_str, space, world_str)], result)
+  end
+
+  def test_walk_replacing_certain_elements
+    result = PandocElement.walk!([para(hello_str, space, world_str)]) { |element| @elements << element.dup; space if element.kind_of?(PandocElement::Str) }
+    assert_equal([para(hello_str, space, world_str), hello_str, space, world_str], @elements)
+    assert_equal([para(space, space, space)], result)
+  end
+
+  def test_walk_replacing_certain_elements_with_nested_elements
+    result = PandocElement.walk!([para(hello_str, space, world_str)]) { |element| @elements << element.dup; plain(soft_break) if element.kind_of?(PandocElement::Str) }
+    assert_equal([para(hello_str, space, world_str), hello_str, soft_break, space, world_str, soft_break], @elements)
+    assert_equal([para(plain(soft_break), space, plain(soft_break))], result)
+  end
+
+  def test_walk_of_hash_of_elements_replacing_some_elements
+    result = PandocElement.walk!('x' => [space], 'y' => [soft_break], 'z' => [null]) { |element| @elements << element.dup; line_break if element.kind_of?(PandocElement::Null) }
+    assert_equal([space, soft_break, null], @elements)
+    assert_equal({ 'x' => [space], 'y' => [soft_break], 'z' => [line_break] }, result)
+  end
+
+  def test_walk_and_remove_element
+    result = PandocElement.walk!([para(hello_str, space, world_str)]) { |element| @elements << element.dup; [] if element.kind_of?(PandocElement::Str) }
+    assert_equal([para(hello_str, space, world_str), hello_str, space, world_str], @elements)
+    assert_equal([para(space)], result)
+  end
+
+  def test_walk_and_add_elements
+    result = PandocElement.walk!([para(hello_str, space, world_str)]) { |element| @elements << element.dup; [line_break, element] if element.kind_of?(PandocElement::Str) }
+    assert_equal([para(hello_str, space, world_str), hello_str, space, world_str], @elements)
+    assert_equal([para(line_break, hello_str, space, line_break, world_str)], result)
+  end
+end

--- a/test/object_walk_test.rb
+++ b/test/object_walk_test.rb
@@ -1,0 +1,63 @@
+require_relative 'test_helper'
+
+class ObjectWalkTest < Minitest::Test
+  include PandocElementHelper
+
+  def setup
+    @elements = []
+  end
+
+  def test_walk_of_single_element
+    result = PandocElement.walk(hello_str) { |element| @elements << element.dup; nil }
+    assert_empty(@elements)
+    assert_equal(hello_str, result)
+  end
+
+  def test_walk_of_array_of_elements
+    result = PandocElement.walk([hello_str, space, world_str]) { |element| @elements << element.dup; nil }
+    assert_equal([hello_str, space, world_str], @elements)
+    assert_equal([hello_str, space, world_str], result)
+  end
+
+  def test_walk_of_hash_of_elements
+    result = PandocElement.walk('x' => [space], 'y' => [soft_break], 'z' => [null]) { |element| @elements << element.dup; nil }
+    assert_equal([space, soft_break, null], @elements)
+    assert_equal({ 'x' => [space], 'y' => [soft_break], 'z' => [null] }, result)
+  end
+
+  def test_nested_walk
+    result = PandocElement.walk([para(hello_str, space, world_str)]) { |element| @elements << element.dup; nil }
+    assert_equal([para(hello_str, space, world_str), hello_str, space, world_str], @elements)
+    assert_equal([para(hello_str, space, world_str)], result)
+  end
+
+  def test_walk_doesnt_replace_elements
+    result = PandocElement.walk([para(hello_str, space, world_str)]) { |element| @elements << element.dup; space if element.kind_of?(PandocElement::Str) }
+    assert_equal([para(hello_str, space, world_str), hello_str, space, world_str], @elements)
+    assert_equal([para(hello_str, space, world_str)], result)
+  end
+
+  def test_walk_doesnt_replace_elements_with_nested_elements
+    result = PandocElement.walk([para(hello_str, space, world_str)]) { |element| @elements << element.dup; plain(soft_break) if element.kind_of?(PandocElement::Str) }
+    assert_equal([para(hello_str, space, world_str), hello_str, space, world_str], @elements)
+    assert_equal([para(hello_str, space, world_str)], result)
+  end
+
+  def test_walk_of_hash_of_elements_doesnt_replace_elements
+    result = PandocElement.walk('x' => [space], 'y' => [soft_break], 'z' => [null]) { |element| @elements << element.dup; line_break if element.kind_of?(PandocElement::Null) }
+    assert_equal([space, soft_break, null], @elements)
+    assert_equal({ 'x' => [space], 'y' => [soft_break], 'z' => [null] }, result)
+  end
+
+  def test_walk_doesnt_remove_elements
+    result = PandocElement.walk([para(hello_str, space, world_str)]) { |element| @elements << element.dup; [] if element.kind_of?(PandocElement::Str) }
+    assert_equal([para(hello_str, space, world_str), hello_str, space, world_str], @elements)
+    assert_equal([para(hello_str, space, world_str)], result)
+  end
+
+  def test_walk_doesnt_add_elements
+    result = PandocElement.walk([para(hello_str, space, world_str)]) { |element| @elements << element.dup; [line_break, element] if element.kind_of?(PandocElement::Str) }
+    assert_equal([para(hello_str, space, world_str), hello_str, space, world_str], @elements)
+    assert_equal([para(hello_str, space, world_str)], result)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,26 @@
+require 'minitest/autorun'
+require 'open3'
+require 'stringio'
+require_relative '../lib/pandoc-filter'
+
+module PandocHelper
+  def ast_to_stream(ast)
+    StringIO.new(JSON.dump(ast))
+  end
+
+  def stream_to_ast(stream)
+    JSON.parse(stream.string)
+  end
+
+  def strip_whitespace(str)
+    spaces = str[/^ +/]
+    str.gsub /^#{spaces}/, ""
+  end
+
+  def to_pandoc_ast(markdown, strip: true)
+    markdown = strip_whitespace(markdown) if strip
+    output, status = Open3.capture2('pandoc -f markdown -t json -s', stdin_data: markdown)
+    raise 'Error capturing pandoc output!' unless status.success?
+    JSON.parse(output)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,11 @@ require 'stringio'
 require_relative '../lib/pandoc-filter'
 
 module PandocHelper
+  def ast(type, value = [])
+    { 't' => type, 'c' => value }
+  end
+
+
   def ast_to_stream(ast)
     StringIO.new(JSON.dump(ast))
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,10 +18,17 @@ module PandocHelper
   end
 
   def to_pandoc_ast(markdown, strip: true)
-    markdown = strip_whitespace(markdown) if strip
-    output, status = Open3.capture2('pandoc -f markdown -t json -s', stdin_data: markdown)
+    JSON.parse pandoc(markdown, to: "json")
+  end
+
+  def pandoc(content, filter: nil, from: "markdown", to: "markdown", strip: true, standalone: true)
+    content = strip_whitespace(content) if strip
+    options = ["-f #{from}", "-t #{to}"]
+    options << "-s" if standalone
+    options << "--filter '#{filter}'" if filter
+    output, status = Open3.capture2({ "RUBYLIB" => File.expand_path("../../lib", __FILE__)}, "pandoc #{options.join(" ")}", stdin_data: content)
     raise 'Error capturing pandoc output!' unless status.success?
-    JSON.parse(output)
+    output
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,11 +4,6 @@ require 'stringio'
 require_relative '../lib/pandoc-filter'
 
 module PandocHelper
-  def ast(type, value = [])
-    { 't' => type, 'c' => value }
-  end
-
-
   def ast_to_stream(ast)
     StringIO.new(JSON.dump(ast))
   end
@@ -27,5 +22,77 @@ module PandocHelper
     output, status = Open3.capture2('pandoc -f markdown -t json -s', stdin_data: markdown)
     raise 'Error capturing pandoc output!' unless status.success?
     JSON.parse(output)
+  end
+end
+
+module PandocAstHelper
+  def ast(type, value = [])
+    { 't' => type, 'c' => value }
+  end
+
+  def hello_str_ast
+    ast('Str', 'hello')
+  end
+
+  def world_str_ast
+    ast('Str', 'world')
+  end
+
+  def space_ast
+    ast('Space')
+  end
+
+  def soft_break_ast
+    ast('SoftBreak')
+  end
+
+  def line_break_ast
+    ast('LineBreak')
+  end
+
+  def null_ast
+    ast('Null')
+  end
+
+  def para_ast(*children)
+    ast('Para', children)
+  end
+
+  def plain_ast(*children)
+    ast('Plain', children)
+  end
+end
+
+module PandocElementHelper
+  def hello_str
+    PandocElement::Str.new('hello')
+  end
+
+  def world_str
+    PandocElement::Str.new('world')
+  end
+
+  def space
+    PandocElement::Space.new
+  end
+
+  def soft_break
+    PandocElement::SoftBreak.new
+  end
+
+  def line_break
+    PandocElement::LineBreak.new
+  end
+
+  def null
+    PandocElement::Null.new
+  end
+
+  def para(*children)
+    PandocElement::Para.new(children)
+  end
+
+  def plain(*children)
+    PandocElement::Plain.new(children)
   end
 end

--- a/test/to_ast_test.rb
+++ b/test/to_ast_test.rb
@@ -56,4 +56,22 @@ class ToAstTest < Minitest::Test
 
     assert_equal(expected, actual)
   end
+
+  def test_link
+    expected = {
+      't' => 'Link', 'c' => [
+        ['id', ['class1', 'class2'], [['key1', 'value1'], ['key2', 'value2']]],
+        [{ 't' => 'Str', 'c' => 'link' }],
+        ['http://example.com', 'This is the title']
+      ]
+    }
+
+    actual = PandocElement::Link.new([
+      PandocElement::Attr.new(['id', ['class1', 'class2'], [['key1', 'value1'], ['key2', 'value2']]]),
+      [PandocElement::Str.new('link')],
+      PandocElement::Target.new(['http://example.com', 'This is the title'])
+    ]).to_ast
+
+    assert_equal(expected, actual)
+  end
 end

--- a/test/to_ast_test.rb
+++ b/test/to_ast_test.rb
@@ -1,24 +1,22 @@
 require_relative 'test_helper'
 
 class ToAstTest < Minitest::Test
+  include PandocHelper
+
   def test_space
-    assert_equal({ 't' => 'Space', 'c' => [] }, PandocElement::Space.new.to_ast)
+    assert_equal(ast('Space'), PandocElement::Space.new.to_ast)
   end
 
   def test_str
-    assert_equal({ 't' => 'Str', 'c' => 'hello' }, PandocElement::Str.new('hello').to_ast)
+    assert_equal(ast('Str', 'hello'), PandocElement::Str.new('hello').to_ast)
   end
 
   def test_with_object
-    assert_equal({ 't' => 'Space', 'c' => [] }, PandocElement.to_ast(PandocElement::Space.new))
+    assert_equal(ast('Space'), PandocElement.to_ast(PandocElement::Space.new))
   end
 
   def test_with_array
-    expected = [
-      { 't' => 'Str', 'c' => 'hello' },
-      { 't' => 'Space', 'c' => [] },
-      { 't' => 'Str', 'c' => 'world' }
-    ]
+    expected = [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')]
 
     actual = PandocElement.to_ast([
       PandocElement::Str.new('hello'),
@@ -30,7 +28,7 @@ class ToAstTest < Minitest::Test
   end
 
   def test_with_hash
-    expected = { 'x' => 'value', 'y' => { 't' => 'Space', 'c' => [] } }
+    expected = { 'x' => 'value', 'y' => ast('Space') }
     actual = PandocElement.to_ast('x' => 'value', 'y' => PandocElement::Space.new)
     assert_equal(expected, actual)
   end
@@ -40,13 +38,7 @@ class ToAstTest < Minitest::Test
   end
 
   def test_para
-    expected = {
-      't' => 'Para', 'c' => [
-        { 't' => 'Str', 'c' => 'hello' },
-        { 't' => 'Space', 'c' => [] },
-        { 't' => 'Str', 'c' => 'world' }
-      ]
-    }
+    expected = ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])
 
     actual = PandocElement::Para.new([
       PandocElement::Str.new('hello'),
@@ -58,13 +50,11 @@ class ToAstTest < Minitest::Test
   end
 
   def test_link
-    expected = {
-      't' => 'Link', 'c' => [
-        ['id', ['class1', 'class2'], [['key1', 'value1'], ['key2', 'value2']]],
-        [{ 't' => 'Str', 'c' => 'link' }],
-        ['http://example.com', 'This is the title']
-      ]
-    }
+    expected = ast('Link', [
+      ['id', ['class1', 'class2'], [['key1', 'value1'], ['key2', 'value2']]],
+      [ast('Str', 'link')],
+      ['http://example.com', 'This is the title']
+    ])
 
     actual = PandocElement::Link.new([
       PandocElement::Attr.new(['id', ['class1', 'class2'], [['key1', 'value1'], ['key2', 'value2']]]),

--- a/test/to_ast_test.rb
+++ b/test/to_ast_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class AstTest < Minitest::Test
+class ToAstTest < Minitest::Test
   def test_space
     assert_equal({ 't' => 'Space', 'c' => [] }, PandocElement::Space.new.to_ast)
   end
@@ -9,11 +9,11 @@ class AstTest < Minitest::Test
     assert_equal({ 't' => 'Str', 'c' => 'hello' }, PandocElement::Str.new('hello').to_ast)
   end
 
-  def test_to_ast_with_object
+  def test_with_object
     assert_equal({ 't' => 'Space', 'c' => [] }, PandocElement.to_ast(PandocElement::Space.new))
   end
 
-  def test_to_ast_with_array
+  def test_with_array
     expected = [
       { 't' => 'Str', 'c' => 'hello' },
       { 't' => 'Space', 'c' => [] },
@@ -29,13 +29,13 @@ class AstTest < Minitest::Test
     assert_equal(expected, actual)
   end
 
-  def test_to_ast_with_hash
+  def test_with_hash
     expected = { 'x' => 'value', 'y' => { 't' => 'Space', 'c' => [] } }
     actual = PandocElement.to_ast('x' => 'value', 'y' => PandocElement::Space.new)
     assert_equal(expected, actual)
   end
 
-  def test_to_ast_with_string
+  def test_with_string
     assert_equal('hello', PandocElement.to_ast('hello'))
   end
 

--- a/test/to_ast_test.rb
+++ b/test/to_ast_test.rb
@@ -2,34 +2,30 @@ require_relative 'test_helper'
 
 class ToAstTest < Minitest::Test
   include PandocHelper
+  include PandocAstHelper
+  include PandocElementHelper
 
   def test_space
-    assert_equal(ast('Space'), PandocElement::Space.new.to_ast)
+    assert_equal(space_ast, space.to_ast)
   end
 
   def test_str
-    assert_equal(ast('Str', 'hello'), PandocElement::Str.new('hello').to_ast)
+    assert_equal(hello_str_ast, hello_str.to_ast)
   end
 
   def test_with_object
-    assert_equal(ast('Space'), PandocElement.to_ast(PandocElement::Space.new))
+    assert_equal(space_ast, PandocElement.to_ast(space))
   end
 
   def test_with_array
-    expected = [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')]
-
-    actual = PandocElement.to_ast([
-      PandocElement::Str.new('hello'),
-      PandocElement::Space.new,
-      PandocElement::Str.new('world')
-    ])
-
+    expected = [hello_str_ast, space_ast, world_str_ast]
+    actual = PandocElement.to_ast([hello_str, space, world_str])
     assert_equal(expected, actual)
   end
 
   def test_with_hash
-    expected = { 'x' => 'value', 'y' => ast('Space') }
-    actual = PandocElement.to_ast('x' => 'value', 'y' => PandocElement::Space.new)
+    expected = { 'x' => 'value', 'y' => space_ast }
+    actual = PandocElement.to_ast('x' => 'value', 'y' => space)
     assert_equal(expected, actual)
   end
 
@@ -38,14 +34,8 @@ class ToAstTest < Minitest::Test
   end
 
   def test_para
-    expected = ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])
-
-    actual = PandocElement::Para.new([
-      PandocElement::Str.new('hello'),
-      PandocElement::Space.new,
-      PandocElement::Str.new('world')
-    ]).to_ast
-
+    expected = para_ast(hello_str_ast, space_ast, world_str_ast)
+    actual = para(hello_str, space, world_str).to_ast
     assert_equal(expected, actual)
   end
 

--- a/test/to_objects_test.rb
+++ b/test/to_objects_test.rb
@@ -1,0 +1,55 @@
+require_relative 'test_helper'
+
+class ToObjectsTest < Minitest::Test
+  def test_space
+    assert_equal(PandocElement::Space.new, PandocElement.to_object('t' => 'Space', 'c' => []))
+  end
+
+  def test_str
+    assert_equal(PandocElement::Str.new('hello'), PandocElement.to_object('t' => 'Str', 'c' => 'hello'))
+  end
+
+  def test_with_array
+    expected = [
+      PandocElement::Str.new('hello'),
+      PandocElement::Space.new,
+      PandocElement::Str.new('world')
+    ]
+
+    actual = PandocElement.to_object([
+      { 't' => 'Str', 'c' => 'hello' },
+      { 't' => 'Space', 'c' => [] },
+      { 't' => 'Str', 'c' => 'world' }
+    ])
+
+    assert_equal(expected, actual)
+  end
+
+  def test_with_non_ast_hash
+    expected = { 'x' => 'value', 'y' => PandocElement::Space.new }
+    actual = PandocElement.to_object('x' => 'value', 'y' => { 't' => 'Space', 'c' => [] })
+    assert_equal(expected, actual)
+  end
+
+  def test_with_string
+    assert_equal('hello', PandocElement.to_object('hello'))
+  end
+
+  def test_para
+    expected = PandocElement::Para.new([
+      PandocElement::Str.new('hello'),
+      PandocElement::Space.new,
+      PandocElement::Str.new('world')
+    ])
+
+    actual = PandocElement.to_object(
+      't' => 'Para', 'c' => [
+        { 't' => 'Str', 'c' => 'hello' },
+        { 't' => 'Space', 'c' => [] },
+        { 't' => 'Str', 'c' => 'world' }
+      ]
+    )
+
+    assert_equal(expected, actual)
+  end
+end

--- a/test/to_objects_test.rb
+++ b/test/to_objects_test.rb
@@ -52,4 +52,22 @@ class ToObjectsTest < Minitest::Test
 
     assert_equal(expected, actual)
   end
+
+  def test_link
+    expected = PandocElement::Link.new([
+      PandocElement::Attr.new(['id', ['class1', 'class2'], [['key1', 'value1'], ['key2', 'value2']]]),
+      [PandocElement::Str.new('link')],
+      PandocElement::Target.new(['http://example.com', 'This is the title'])
+    ])
+
+    actual = PandocElement.to_object(
+      't' => 'Link', 'c' => [
+        ['id', ['class1', 'class2'], [['key1', 'value1'], ['key2', 'value2']]],
+        [{ 't' => 'Str', 'c' => 'link' }],
+        ['http://example.com', 'This is the title']
+      ]
+    )
+
+    assert_equal(expected, actual)
+  end
 end

--- a/test/to_objects_test.rb
+++ b/test/to_objects_test.rb
@@ -1,12 +1,14 @@
 require_relative 'test_helper'
 
 class ToObjectsTest < Minitest::Test
+  include PandocHelper
+
   def test_space
-    assert_equal(PandocElement::Space.new, PandocElement.to_object('t' => 'Space', 'c' => []))
+    assert_equal(PandocElement::Space.new, PandocElement.to_object(ast('Space')))
   end
 
   def test_str
-    assert_equal(PandocElement::Str.new('hello'), PandocElement.to_object('t' => 'Str', 'c' => 'hello'))
+    assert_equal(PandocElement::Str.new('hello'), PandocElement.to_object(ast('Str', 'hello')))
   end
 
   def test_with_array
@@ -16,18 +18,13 @@ class ToObjectsTest < Minitest::Test
       PandocElement::Str.new('world')
     ]
 
-    actual = PandocElement.to_object([
-      { 't' => 'Str', 'c' => 'hello' },
-      { 't' => 'Space', 'c' => [] },
-      { 't' => 'Str', 'c' => 'world' }
-    ])
-
+    actual = PandocElement.to_object([ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])
     assert_equal(expected, actual)
   end
 
   def test_with_non_ast_hash
     expected = { 'x' => 'value', 'y' => PandocElement::Space.new }
-    actual = PandocElement.to_object('x' => 'value', 'y' => { 't' => 'Space', 'c' => [] })
+    actual = PandocElement.to_object('x' => 'value', 'y' => ast('Space'))
     assert_equal(expected, actual)
   end
 
@@ -42,14 +39,7 @@ class ToObjectsTest < Minitest::Test
       PandocElement::Str.new('world')
     ])
 
-    actual = PandocElement.to_object(
-      't' => 'Para', 'c' => [
-        { 't' => 'Str', 'c' => 'hello' },
-        { 't' => 'Space', 'c' => [] },
-        { 't' => 'Str', 'c' => 'world' }
-      ]
-    )
-
+    actual = PandocElement.to_object(ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')]))
     assert_equal(expected, actual)
   end
 
@@ -60,13 +50,11 @@ class ToObjectsTest < Minitest::Test
       PandocElement::Target.new(['http://example.com', 'This is the title'])
     ])
 
-    actual = PandocElement.to_object(
-      't' => 'Link', 'c' => [
-        ['id', ['class1', 'class2'], [['key1', 'value1'], ['key2', 'value2']]],
-        [{ 't' => 'Str', 'c' => 'link' }],
-        ['http://example.com', 'This is the title']
-      ]
-    )
+    actual = PandocElement.to_object(ast('Link', [
+      ['id', ['class1', 'class2'], [['key1', 'value1'], ['key2', 'value2']]],
+      [ast('Str', 'link')],
+      ['http://example.com', 'This is the title']
+    ]))
 
     assert_equal(expected, actual)
   end

--- a/test/to_objects_test.rb
+++ b/test/to_objects_test.rb
@@ -2,29 +2,26 @@ require_relative 'test_helper'
 
 class ToObjectsTest < Minitest::Test
   include PandocHelper
+  include PandocAstHelper
+  include PandocElementHelper
 
   def test_space
-    assert_equal(PandocElement::Space.new, PandocElement.to_object(ast('Space')))
+    assert_equal(space, PandocElement.to_object(space_ast))
   end
 
   def test_str
-    assert_equal(PandocElement::Str.new('hello'), PandocElement.to_object(ast('Str', 'hello')))
+    assert_equal(hello_str, PandocElement.to_object(hello_str_ast))
   end
 
   def test_with_array
-    expected = [
-      PandocElement::Str.new('hello'),
-      PandocElement::Space.new,
-      PandocElement::Str.new('world')
-    ]
-
-    actual = PandocElement.to_object([ast('Str', 'hello'), ast('Space'), ast('Str', 'world')])
+    expected = [hello_str, space, world_str]
+    actual = PandocElement.to_object([hello_str_ast, space_ast, world_str_ast])
     assert_equal(expected, actual)
   end
 
   def test_with_non_ast_hash
-    expected = { 'x' => 'value', 'y' => PandocElement::Space.new }
-    actual = PandocElement.to_object('x' => 'value', 'y' => ast('Space'))
+    expected = { 'x' => 'value', 'y' => space }
+    actual = PandocElement.to_object('x' => 'value', 'y' => space_ast)
     assert_equal(expected, actual)
   end
 
@@ -33,13 +30,8 @@ class ToObjectsTest < Minitest::Test
   end
 
   def test_para
-    expected = PandocElement::Para.new([
-      PandocElement::Str.new('hello'),
-      PandocElement::Space.new,
-      PandocElement::Str.new('world')
-    ])
-
-    actual = PandocElement.to_object(ast('Para', [ast('Str', 'hello'), ast('Space'), ast('Str', 'world')]))
+    expected = para(hello_str, space, world_str)
+    actual = PandocElement.to_object(para_ast(hello_str_ast, space_ast, world_str_ast))
     assert_equal(expected, actual)
   end
 


### PR DESCRIPTION
This branch adds an object structure for filters, so rather than manipulating the raw AST, you can manipulate objects. I've added some examples and a lot of tests, but I'd still like to document the key methods and add some markdown documentation before I would consider this ready to accept.

In the meantime, I wanted to create the PR so you can evaluate if this is something you even want in the gem, or if you want any big changes or anything.

If you'd rather not include the object based filtering, I can break that out into a separate gem and just leave the tests, or whatever bits you would like to keep.

If you would like to include the object filtering, I'd be happy to implement any changes you would like included.

I was also wondering if you would like some kind of versioning included, so that a user filtering with Pandoc 1.16 could use the gem, as well as a user filtering with Pandoc 1.12. I think it would be relatively easy to implement if that sounds like something you want.
